### PR TITLE
Add gamekeeper field to user admin page

### DIFF
--- a/mysite/academic_adventure/admin.py
+++ b/mysite/academic_adventure/admin.py
@@ -3,13 +3,19 @@ from django.contrib.auth.admin import UserAdmin
 from .models import CustomUser, Event, Society
 
 class CustomUserAdmin(UserAdmin):
+    """
+    Custom user admin to allow for the extended user attributes
+    to be displayed on the admin.py page.
+    """
+    #Fields in the creation form
     fieldsets = (
-        *UserAdmin.fieldsets,
+        *UserAdmin.fieldsets, #Fields in the default user admin page
         (
             'Custom user fields',
             {
                 'fields':(
-                    "gamekeeper",
+                    "gamekeeper", #Field to determine if a user is a gamekeeper
+                    #Can be used to set gamekeepers in the system
                 ),
             },
         ),


### PR DESCRIPTION
Added the gamekeeper field to the user admin page so that a superuser can set gamekeepers through the admin page.